### PR TITLE
Add density_plotter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ you would like to add:
 | File | Purpose | Maintainer | Library |
 | --- | --- | --- | --- |
 | single_cell/add_module_score_from_excel_gene_sets.R | R code for reading gene sets from an excel file, running Seurat::AddModuleScore, and visualizing the results | Dan | No |
+| single_cell/density_plotter.R | When `source()`'d, defines an R function that plots density of clusters across the umap space | Dan | Not yet |
 | single_cell/annotation_import.R | When `source()`'d, defines an R function for pulling annotations into Seurat or SCE objects from a csv. An [example 'annots_file'](single_cell/annotation_import_example.csv) and [txt version of the function documentation](single_cell/annotation_import.txt) is also included. | Dan | No, but could be! | 
 | single_cell/CITEseq/subcluster/function.R | When `source()`'d, defines an R function for subclustering Seurat CITEseq data. A script.R is also included to provide example usage. | Dan | No |
 | count_cores | a command line executable that allows a user to 1) self-monitor their active cores on `krummellab` nodes (default) or 2) use optional flags to query all DSCoLab active jobs to test for core monopoly | Rebecca | Yes |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ you would like to add:
 | File | Purpose | Maintainer | Library |
 | --- | --- | --- | --- |
 | single_cell/add_module_score_from_excel_gene_sets.R | R code for reading gene sets from an excel file, running Seurat::AddModuleScore, and visualizing the results | Dan | No |
-| single_cell/density_plotter.R | When `source()`'d, defines an R function that plots density of clusters across the umap space | Dan | Not yet |
-| single_cell/annotation_import.R | When `source()`'d, defines an R function for pulling annotations into Seurat or SCE objects from a csv. An [example 'annots_file'](single_cell/annotation_import_example.csv) and [txt version of the function documentation](single_cell/annotation_import.txt) is also included. | Dan | No, but could be! | 
+| single_cell/density_plotter.R | When `source()`'d, defines an R function that plots density of clusters across the umap space | Dan | Yes |
+| single_cell/annotation_import.R | When `source()`'d, defines an R function for pulling annotations into Seurat or SCE objects from a csv. An [example 'annots_file'](single_cell/annotation_import_example.csv) and [txt version of the function documentation](single_cell/annotation_import.txt) is also included. | Dan | Yes | 
 | single_cell/CITEseq/subcluster/function.R | When `source()`'d, defines an R function for subclustering Seurat CITEseq data. A script.R is also included to provide example usage. | Dan | No |
 | count_cores | a command line executable that allows a user to 1) self-monitor their active cores on `krummellab` nodes (default) or 2) use optional flags to query all DSCoLab active jobs to test for core monopoly | Rebecca | Yes |

--- a/single_cell/density_plotter.R
+++ b/single_cell/density_plotter.R
@@ -1,0 +1,53 @@
+density_plotter <- function(
+    object,
+    clustering,
+    split.by = NULL,
+    main = clustering,
+    scale_legend=3,
+    color.var = NULL,
+    ...) {
+
+    if (!requireNamespace("dittoSeq")) {
+        stop('The dittoSeq package is required to run this function.')
+    }
+
+    if (!identical(color.var, NULL)) {
+        warning("Ignoring the requested 'color.var' as density would then be plotted by dittoDimHex using opacity instead of color, and thus defeat the entire purpose of this function.")
+    }
+
+    if (!identical(split.by, NULL)) {
+        warning("This function uses splitting to show density of each individual cluster. Additional use of the 'split.by' input is allowed but limited and not recommended.")
+        if (length(split.by)>1) {
+            warning("In favor of faceting by clustering, split.by element '", split.by[2], "' will be ignored.")
+            split.by <- split.by[1]
+        }
+    }
+    split.by <- c(clustering, split.by)
+
+    legend_breaks <- c(
+        0, 0.001, 0.005,
+        0.01, 0.05,
+        0.1, 0.2, 1)
+
+    lightblue <- dittoSeq::dittoColors()[2]
+    yellow <- dittoSeq::dittoColors()[4]
+    orangered <- dittoSeq::dittoColors()[6]
+    legend_colors <- c(
+        "grey95",
+        Lighten(lightblue, 0.6),
+        Lighten(lightblue, 0.3),
+        Lighten(yellow, 0.3),
+        Lighten(orangered, 0.3),
+        orangered,
+        Darken(orangered, 0.3),
+        Darken(orangered, 0.75))
+
+    dittoSeq::dittoDimHex(
+        object, split.by = split.by, main = main, ...) +
+        scale_fill_gradientn(
+            name = "Cells",
+            values = legend_breaks, colors = legend_colors,
+            breaks = function(limits) {c(1, 50, 200, 500, scales::breaks_extended(5)(limits))}
+        ) +
+        theme(legend.key.height = unit(1.2*scale_legend, 'lines'))
+}

--- a/single_cell/density_plotter.R
+++ b/single_cell/density_plotter.R
@@ -10,7 +10,8 @@
 #' @param dont_warn Logical. Set to TRUE to block output of \code{color.var} and \code{split.by} input-related warnings.
 #' @return A ggplot object where colored hexagonal bins are used to summarize cell density of \code{clustering}-identities across the UMAP (or dimensionality reduction) space.
 #'
-#' Alternatively, if \code{data.out=TRUE}, a list containing
+#' Alternatively, if \code{data.out=TRUE}, a list containing two slots is output: the plot (named 'plot'), and a data.table containing the underlying data for target cells (named 'data').
+#' @seealso \code{\link[dittoSeq]{dittoDimHex}}
 #' @author Daniel Bunis
 #' @examples
 #' # We'll use the Seurat example dataset for this example

--- a/single_cell/density_plotter.R
+++ b/single_cell/density_plotter.R
@@ -1,53 +1,115 @@
+### This script provides a visualization function that is helpful for assessing cluster dispersion
+# (Documenting in roxygen syntax to be "library"-ready)
+#' Visualize the density of each cluster over the umap space, wraps dittoDimHex
+#' @param object A Seurat or SingleCellExperiment object
+#' @param clustering String, the name of the metadata to facet by, especially one holding cells' cluster identities. Extra detail: This value will be passed to \code{\link[dittoSeq]{dittoDimHex}} in its \code{split.by} argument.
+#' @param scale_legend Number, a scale factor for the size of the density legend. By default, this legend is expanded to 3x the normal legend size in order to be able to reveal the multiple color changes in its lower end. 
+#' @param main,data.out,... Parameters passed on to \code{\link[dittoSeq]{dittoDimHex}}
+#' @param split.by NULL or a Single String giving the name of a additional metadata to facet by. Not recommended normally, but not blocked as there may be valid use-cases.
+#' @param color.var Ignored. Usage of this parameter of \code{\link[dittoSeq]{dittoDimHex}} changes density to be plotted via opacity instead of color, which would defeat the entire purpose of this wrapper function.
+#' @param dont_warn Logical. Set to TRUE to block output of \code{color.var} and \code{split.by} input-related warnings.
+#' @return A ggplot object where colored hexagonal bins are used to summarize cell density of \code{clustering}-identities across the UMAP (or dimensionality reduction) space.
+#'
+#' Alternatively, if \code{data.out=TRUE}, a list containing
+#' @author Daniel Bunis
+#' @examples
+#' # We'll use the Seurat example dataset for this example
+#' sobj <- SeuratObject::pbmc_small
+#' 
+#' # We'll also make use of the fact that dittoSeq allows use of the string
+#' #  "ident" to refererence the 'Idents(seurat_object)' because Seurat
+#' #  could change the metadata name sof 'pbmc_small' at any time.
+#' 
+#' density_plotter(
+#'     sobj,
+#'     "ident" # or the name of your desired clustering metadata
+#' )
+#' 
+#' # You make the density legend bigger or smaller by adjusting the
+#' #  'scale_legend' input.
+#' density_plotter(sobj, "ident",
+#'     scale_legend = 1
+#' )
+#' 
+#' # You can also make use of additional dittoDimHex inputs.
+#' density_plotter(sobj, "ident",
+#'     bins = 5,
+#'     reduction.use = "pca",
+#'     main = "Cluster Densities on PCA"
+#' )
+#' 
+#' # You can also turn off the warning from supplying an extra 'split.by'
+#' #  argument by adding 'dont_warn = TRUE'.
+#' density_plotter(sobj, "ident",
+#'     split.by = "groups",
+#'     dont_warn = TRUE)
+#'
 density_plotter <- function(
-    object,
-    clustering,
-    split.by = NULL,
-    main = clustering,
-    scale_legend=3,
-    color.var = NULL,
-    ...) {
-
-    if (!requireNamespace("dittoSeq")) {
+        object,
+        clustering,
+        scale_legend=3,
+        main = clustering,
+        data.out = FALSE,
+        dont_warn = FALSE,
+        split.by = NULL,
+        color.var = NULL,
+        ...) {
+    
+    warn_if <- function(..., do = !dont_warn) {
+        if (do) warning(...)
+    }
+    
+    if (!requireNamespace("dittoSeq", quietly = TRUE)) {
         stop('The dittoSeq package is required to run this function.')
     }
-
+    
     if (!identical(color.var, NULL)) {
-        warning("Ignoring the requested 'color.var' as density would then be plotted by dittoDimHex using opacity instead of color, and thus defeat the entire purpose of this function.")
+        warn_if("Ignoring the requested 'color.var' as density would then be plotted by dittoDimHex using opacity instead of color, and thus defeat the entire purpose of this function.")
     }
-
+    
     if (!identical(split.by, NULL)) {
-        warning("This function uses splitting to show density of each individual cluster. Additional use of the 'split.by' input is allowed but limited and not recommended.")
+        warn_if("This function uses splitting to show density of each individual cluster. Additional use of the 'split.by' input is allowed but limited and not recommended.")
         if (length(split.by)>1) {
-            warning("In favor of faceting by clustering, split.by element '", split.by[2], "' will be ignored.")
+            warn_if("In favor of faceting by clustering, split.by element '", split.by[2], "' will be ignored.")
             split.by <- split.by[1]
         }
     }
     split.by <- c(clustering, split.by)
-
+    
     legend_breaks <- c(
         0, 0.001, 0.005,
         0.01, 0.05,
         0.1, 0.2, 1)
-
+    
     lightblue <- dittoSeq::dittoColors()[2]
     yellow <- dittoSeq::dittoColors()[4]
     orangered <- dittoSeq::dittoColors()[6]
     legend_colors <- c(
         "grey95",
-        Lighten(lightblue, 0.6),
-        Lighten(lightblue, 0.3),
-        Lighten(yellow, 0.3),
-        Lighten(orangered, 0.3),
+        dittoSeq::Lighten(lightblue, 0.6),
+        dittoSeq::Lighten(lightblue, 0.3),
+        dittoSeq::Lighten(yellow, 0.3),
+        dittoSeq::Lighten(orangered, 0.3),
         orangered,
-        Darken(orangered, 0.3),
-        Darken(orangered, 0.75))
-
-    dittoSeq::dittoDimHex(
-        object, split.by = split.by, main = main, ...) +
-        scale_fill_gradientn(
-            name = "Cells",
-            values = legend_breaks, colors = legend_colors,
-            breaks = function(limits) {c(1, 50, 200, 500, scales::breaks_extended(5)(limits))}
-        ) +
-        theme(legend.key.height = unit(1.2*scale_legend, 'lines'))
+        dittoSeq::Darken(orangered, 0.3),
+        dittoSeq::Darken(orangered, 0.75))
+    mod_plot <- function(p, expand_legend=scale_legend, breaks=legend_breaks, colors=legend_colors) {
+        p + 
+            ggplot2::scale_fill_gradientn(
+                name = "Cells",
+                values = breaks, colors = colors,
+                breaks = function(limits) {c(1, 50, 200, 500, scales::breaks_extended(5)(limits))}
+            ) +
+            ggplot2::theme(legend.key.height = ggplot2::unit(1.2*expand_legend, 'lines'))
+    }
+    
+    ditto_out <- dittoSeq::dittoDimHex(
+        object, split.by = split.by, main = main, data.out = data.out, ...)
+    
+    if (data.out) {
+        ditto_out$plot <- mod_plot(ditto_out$p)
+        ditto_out
+    } else {
+        mod_plot(ditto_out)
+    }
 }

--- a/single_cell/density_plotter.txt
+++ b/single_cell/density_plotter.txt
@@ -1,0 +1,100 @@
+Visualize the density of each cluster over the umap space, wraps
+dittoDimHex
+
+Description:
+
+     Visualize the density of each cluster over the umap space, wraps
+     dittoDimHex
+
+Usage:
+
+     density_plotter(
+       object,
+       clustering,
+       scale_legend = 3,
+       main = clustering,
+       data.out = FALSE,
+       dont_warn = FALSE,
+       split.by = NULL,
+       color.var = NULL,
+       ...
+     )
+     
+Arguments:
+
+  object: A Seurat or SingleCellExperiment object
+
+clustering: String, the name of the metadata to facet by, especially
+          one holding cells' cluster identities. Extra detail: This
+          value will be passed to ‘dittoDimHex’ in its ‘split.by’
+          argument.
+
+scale_legend: Number, a scale factor for the size of the density
+          legend. By default, this legend is expanded to 3x the normal
+          legend size in order to be able to reveal the multiple color
+          changes in its lower end.
+
+main, data.out, ...: Parameters passed on to ‘dittoDimHex’
+
+dont_warn: Logical. Set to TRUE to block output of ‘color.var’ and
+          ‘split.by’ input-related warnings.
+
+split.by: NULL or a Single String giving the name of a additional
+          metadata to facet by. Not recommended normally, but not
+          blocked as there may be valid use-cases.
+
+color.var: Ignored. Usage of this parameter of ‘dittoDimHex’ changes
+          density to be plotted via opacity instead of color, which
+          would defeat the entire purpose of this wrapper function.
+
+Value:
+
+     A ggplot object where colored hexagonal bins are used to summarize
+     cell density of ‘clustering’-identities across the UMAP (or
+     dimensionality reduction) space.
+
+     Alternatively, if ‘data.out=TRUE’, a list containing two slots is
+     output: the plot (named 'plot'), and a data.table containing the
+     underlying data for target cells (named 'data').
+
+Author(s):
+
+     Daniel Bunis
+
+See Also:
+
+     ‘dittoDimHex’
+
+Examples:
+
+     # We'll use the Seurat example dataset for this example
+     sobj <- SeuratObject::pbmc_small
+     
+     # We'll also make use of the fact that dittoSeq allows use of the string
+     #  "ident" to refererence the 'Idents(seurat_object)' because Seurat
+     #  could change the metadata name sof 'pbmc_small' at any time.
+     
+     density_plotter(
+         sobj,
+         "ident" # or the name of your desired clustering metadata
+     )
+     
+     # You make the density legend bigger or smaller by adjusting the
+     #  'scale_legend' input.
+     density_plotter(sobj, "ident",
+         scale_legend = 1
+     )
+     
+     # You can also make use of additional dittoDimHex inputs.
+     density_plotter(sobj, "ident",
+         bins = 5,
+         reduction.use = "pca",
+         main = "Cluster Densities on PCA"
+     )
+     
+     # You can also turn off the warning from supplying an extra 'split.by'
+     #  argument by adding 'dont_warn = TRUE'.
+     density_plotter(sobj, "ident",
+         split.by = "groups",
+         dont_warn = TRUE)
+     


### PR DESCRIPTION
Adds a visualization function that is useful for assessment of clustering quality.

It plots density of each cluster over the umap space by wrapping dittoDimHex.  Primarily: 1) faceting is used to display clustering (or whatever other chosen discrete metadata), and 2) the 'fill' scale used to display cell density is replaced with one that provides better discrimination between the lower density differences.

ToDo:
- [x] document
- [x] test